### PR TITLE
Re-add Voicechat bundled in as default

### DIFF
--- a/app_pojavlauncher/src/main/assets/jsons/modmanager.json
+++ b/app_pojavlauncher/src/main/assets/jsons/modmanager.json
@@ -21,6 +21,10 @@
         "platform": "modrinth"
       },
       {
+        "slug": "simple-voice-chat",
+        "platform": "modrinth"
+      },
+      {
         "slug": "lithium",
         "platform": "modrinth"
       },
@@ -40,6 +44,10 @@
       },
       {
         "slug": "lithium",
+        "platform": "modrinth"
+      },
+      {
+        "slug": "simple-voice-chat",
         "platform": "modrinth"
       },
       {


### PR DESCRIPTION
changes the json to put it back, though without the github repo.