### PR TITLE
Add no chat reports as a autoinstalled mod

### DIFF
--- a/app_pojavlauncher/src/main/assets/jsons/modmanager.json
+++ b/app_pojavlauncher/src/main/assets/jsons/modmanager.json
@@ -35,6 +35,10 @@
       {
         "slug": "vivecraft",
         "platform": "github"
+      },
+      {
+        "slug": "no-chat-reports",
+        "platform": "modrinth"
       }
     ],
     "1.19.2": [
@@ -61,7 +65,10 @@
       {
         "slug": "vivecraft",
         "platform": "github"
-
+      },
+      {
+        "slug": "no-chat-reports",
+        "platform": "modrinth"
       }
     ]
   }


### PR DESCRIPTION
Really useful, protects players but still allows chat reports if needed